### PR TITLE
feat: add scroll indicator to hero section

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -58,6 +58,7 @@ body {
 }
 
 .section {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/app.vue
+++ b/app.vue
@@ -58,7 +58,6 @@ body {
 }
 
 .section {
-  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -1,17 +1,21 @@
 <template>
   <div class="section center">
     <h1 class="typewriter">{{ text }}<span ref="cursorEl" class="cursor">_</span></h1>
+    <div class="scroll-indicator" :class="{ visible: showIndicator }" aria-hidden="true">
+      <span class="scroll-arrow"></span>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 const text = ref('');
 const fullText = 'Dive into the "Federated" universe!!'; // 表示するテキスト
 const index = ref(0);
 const speed = 100; // タイピング速度（ミリ秒）
 const cursorEl = ref<HTMLElement | null>(null);
+const showIndicator = ref(false);
 
 const typeEffect = () => {
   if (index.value < fullText.length) {
@@ -19,13 +23,25 @@ const typeEffect = () => {
     index.value++;
     setTimeout(typeEffect, speed);
   } else {
-    // タイピングが完了したらカーソル点滅
+    // タイピングが完了したらカーソル点滅・インジケーター表示
     cursorEl.value?.classList.add('blink');
+    showIndicator.value = true;
+  }
+};
+
+const onScroll = () => {
+  if (window.scrollY > 50) {
+    showIndicator.value = false;
   }
 };
 
 onMounted(() => {
   typeEffect();
+  window.addEventListener('scroll', onScroll, { passive: true });
+});
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll);
 });
 </script>
 
@@ -52,6 +68,38 @@ onMounted(() => {
 @keyframes blink {
   to {
     visibility: hidden;
+  }
+}
+
+.scroll-indicator {
+  position: absolute;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.8s ease;
+}
+
+.scroll-indicator.visible {
+  opacity: 1;
+}
+
+.scroll-arrow {
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-right: 2px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.6);
+  transform: rotate(45deg);
+  animation: bounce 1.2s ease-in-out infinite;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: rotate(45deg) translateY(0);
+  }
+  50% {
+    transform: rotate(45deg) translateY(6px);
   }
 }
 </style>

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -14,12 +14,13 @@ const text = ref('');
 const fullText = 'Dive into the "Federated" universe!!'; // 表示するテキスト
 const index = ref(0);
 const speed = 100; // タイピング速度（ミリ秒）
+const HIDE_SCROLL_THRESHOLD_PX = 50;
 const cursorEl = ref<HTMLElement | null>(null);
 const showIndicator = ref(false);
 let timerId: ReturnType<typeof setTimeout> | undefined;
 
 const onScroll = () => {
-  if (window.scrollY > 50) {
+  if (window.scrollY > HIDE_SCROLL_THRESHOLD_PX) {
     showIndicator.value = false;
     window.removeEventListener('scroll', onScroll);
   }
@@ -33,7 +34,7 @@ const typeEffect = () => {
   } else {
     // タイピングが完了したらカーソル点滅・インジケーター表示（既にスクロール済みなら表示しない）
     cursorEl.value?.classList.add('blink');
-    if (window.scrollY <= 50) {
+    if (window.scrollY <= HIDE_SCROLL_THRESHOLD_PX) {
       showIndicator.value = true;
       window.addEventListener('scroll', onScroll, { passive: true });
     }
@@ -99,6 +100,7 @@ onUnmounted(() => {
   height: 1.5rem;
   border-right: 2px solid rgba(255, 255, 255, 0.6);
   border-bottom: 2px solid rgba(255, 255, 255, 0.6);
+  transform: rotate(45deg);
   animation: bounce 1.2s ease-in-out infinite;
 }
 

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -99,16 +99,15 @@ onUnmounted(() => {
   height: 1.5rem;
   border-right: 2px solid rgba(255, 255, 255, 0.6);
   border-bottom: 2px solid rgba(255, 255, 255, 0.6);
-  transform: rotate(45deg);
   animation: bounce 1.2s ease-in-out infinite;
 }
 
 @keyframes bounce {
   0%, 100% {
-    transform: rotate(45deg) translateY(0);
+    transform: translateY(0) rotate(45deg);
   }
   50% {
-    transform: rotate(45deg) translateY(6px);
+    transform: translateY(6px) rotate(45deg);
   }
 }
 

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -16,39 +16,45 @@ const index = ref(0);
 const speed = 100; // タイピング速度（ミリ秒）
 const cursorEl = ref<HTMLElement | null>(null);
 const showIndicator = ref(false);
-
-const typeEffect = () => {
-  if (index.value < fullText.length) {
-    text.value += fullText.charAt(index.value);
-    index.value++;
-    setTimeout(typeEffect, speed);
-  } else {
-    // タイピングが完了したらカーソル点滅・インジケーター表示（既にスクロール済みなら表示しない）
-    cursorEl.value?.classList.add('blink');
-    onScroll();
-  }
-};
+let timerId: ReturnType<typeof setTimeout> | undefined;
 
 const onScroll = () => {
   if (window.scrollY > 50) {
     showIndicator.value = false;
     window.removeEventListener('scroll', onScroll);
+  }
+};
+
+const typeEffect = () => {
+  if (index.value < fullText.length) {
+    text.value += fullText.charAt(index.value);
+    index.value++;
+    timerId = setTimeout(typeEffect, speed);
   } else {
-    showIndicator.value = true;
+    // タイピングが完了したらカーソル点滅・インジケーター表示（既にスクロール済みなら表示しない）
+    cursorEl.value?.classList.add('blink');
+    if (window.scrollY <= 50) {
+      showIndicator.value = true;
+      window.addEventListener('scroll', onScroll, { passive: true });
+    }
   }
 };
 
 onMounted(() => {
   typeEffect();
-  window.addEventListener('scroll', onScroll, { passive: true });
 });
 
 onUnmounted(() => {
+  clearTimeout(timerId);
   window.removeEventListener('scroll', onScroll);
 });
 </script>
 
 <style scoped>
+.section {
+  position: relative;
+}
+
 .typewriter {
   font-family: 'JetBrains Mono', sans-serif;
   font-size: 3rem;

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -23,15 +23,18 @@ const typeEffect = () => {
     index.value++;
     setTimeout(typeEffect, speed);
   } else {
-    // タイピングが完了したらカーソル点滅・インジケーター表示
+    // タイピングが完了したらカーソル点滅・インジケーター表示（既にスクロール済みなら表示しない）
     cursorEl.value?.classList.add('blink');
-    showIndicator.value = true;
+    onScroll();
   }
 };
 
 const onScroll = () => {
   if (window.scrollY > 50) {
     showIndicator.value = false;
+    window.removeEventListener('scroll', onScroll);
+  } else {
+    showIndicator.value = true;
   }
 };
 
@@ -100,6 +103,15 @@ onUnmounted(() => {
   }
   50% {
     transform: rotate(45deg) translateY(6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-indicator {
+    transition: none;
+  }
+  .scroll-arrow {
+    animation: none;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- タイピングアニメーション完了後、ヒーローセクション下部にスクロールインジケーター（下向き矢印）をフェードイン表示
- 矢印は上下にバウンスしてスクロールを促す
- 50px スクロールするとフェードアウト

## Test plan

- [ ] タイピングアニメーション完了後に矢印が表示されることを確認
- [ ] スクロール後に矢印が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)