### PR TITLE
chore: add Dependabot weekly npm update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` を追加し、npm 依存関係の週次自動チェックを設定

## Test plan
- [ ] PR マージ後、GitHub の Dependabot 設定で weekly スケジュールが有効になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)