### PR TITLE
fix: Heroセクションのタイプライター効果を改善

### DIFF
--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="section center active">
-    <h1 class="typewriter">
-      {{ text }}<span ref="cursorEl" class="cursor">_</span>
-    </h1>
+    <div class="typewriter-wrapper">
+      <h1 class="typewriter typewriter-ghost" aria-hidden="true">{{ fullText }}_</h1>
+      <h1 class="typewriter typewriter-visible">{{ text }}<span ref="cursorEl" class="cursor">_</span></h1>
+    </div>
     <div
       class="scroll-indicator"
       :class="{ visible: showIndicator }"
@@ -47,7 +48,22 @@ const typeEffect = () => {
 };
 
 onMounted(() => {
-  typeEffect();
+  const el = cursorEl.value;
+  if (!el) {
+    typeEffect();
+    return;
+  }
+  el.classList.add('blink');
+  let count = 0;
+  const onIteration = () => {
+    count++;
+    if (count >= 3) {
+      el.removeEventListener('animationiteration', onIteration);
+      el.classList.remove('blink');
+      typeEffect();
+    }
+  };
+  el.addEventListener('animationiteration', onIteration);
 });
 
 onUnmounted(() => {
@@ -61,15 +77,33 @@ onUnmounted(() => {
   position: relative;
 }
 
+.typewriter-wrapper {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+}
+
 .typewriter {
   font-family: 'JetBrains Mono', sans-serif;
-  font-size: 3rem;
+  /* 3.5vw でビューポート幅に追従、モバイル下限 0.7rem、デスクトップ上限 3rem */
+  font-size: clamp(0.7rem, 3.5vw, 3rem);
   font-weight: 500;
   color: white;
-  text-align: center;
-  white-space: normal;
-  word-wrap: break-word;
-  overflow: hidden;
+  white-space: nowrap;
+  margin: 0;
+}
+
+.typewriter-ghost {
+  visibility: hidden;
+  user-select: none;
+  pointer-events: none;
+}
+
+.typewriter-visible {
+  position: absolute;
+  top: 0;
+  left: 0;
+  text-align: left;
 }
 
 .cursor {

--- a/components/TopSection.vue
+++ b/components/TopSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="section center">
+  <div class="section center active">
     <h1 class="typewriter">
       {{ text }}<span ref="cursorEl" class="cursor">_</span>
     </h1>


### PR DESCRIPTION
## 変更内容

- **フェードイン無効化**: `.section` クラスの初期 `opacity: 0` によりページロード時にHeroが一瞬見えなくなる問題を修正。初期クラスに `active` を追加
- **タイプ開始前のカーソル点滅**: タイプライター開始前にカーソルを3回点滅させてターミナル感を演出（`animationiteration` イベントで3サイクルをカウント）
- **位置固定タイピング**: ghost要素で最終テキスト幅を先に確保し、`position: absolute` で左端固定タイピングを実現。従来はセンタリングにより文字が中央から両側に広がっていた
- **レスポンシブ対応**: `font-size: clamp(0.7rem, 3.5vw, 3rem)` でモバイル〜デスクトップ全幅で1行に収まるよう調整

## テスト

- [ ] デスクトップでページロード時の動作確認（フェードなし → カーソル3回点滅 → タイプ開始）
- [ ] モバイルサイズでテキストが1行に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)