### PR TITLE
fix: スクロール時にセクションが消える問題を修正

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -35,8 +35,7 @@ onMounted(() => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           entry.target.classList.add('active');
-        } else {
-          entry.target.classList.remove('active');
+          observer?.unobserve(entry.target);
         }
       });
     },


### PR DESCRIPTION
## 問題

モバイルで一番下までスクロールすると、ビューポートから外れたセクションの `.active` クラスが除去され、テキストが消えていた。

## 原因

`IntersectionObserver` の `else` ブランチで `classList.remove('active')` を呼んでいたため。

## 修正

一度 `active` になったセクションは `unobserve()` で監視から外し、以降スクロール位置に関わらず表示を維持するよう変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)